### PR TITLE
fix: add current directory for debugging getPackageDir

### DIFF
--- a/scripts/src/custard.ts
+++ b/scripts/src/custard.ts
@@ -124,7 +124,7 @@ switch (process.env.CUSTARD_VERBOSE || 'info') {
  * @returns list of affected packages
  */
 export function affected(config: Config, diffs: string[]): string[] {
-  console.log(`affected: current directory ${process.cwd()}`)
+  console.log(`affected: current directory ${process.cwd()}`);
   const packages = matchPackages(config, diffs);
   if (packages.includes('.')) {
     console.error(


### PR DESCRIPTION
supports debugging issues where no packages are detected, where "path 'null' does not exist, it might have been removed"